### PR TITLE
DGDM-20-Add-salary-model-to-economics-submodel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "the-datagarden-models"
-version = "1.6.16"
+version = "1.6.18"
 description = "Base data models for the datagarden."
 readme = "README.rst"
 requires-python = ">=3.10"

--- a/src/datagarden_models/models/household/economics.py
+++ b/src/datagarden_models/models/household/economics.py
@@ -26,7 +26,7 @@ class HouseholdIncome(DataGardenSubModel):
     average_income: Optional[EconomicsValue] = Field(default=None, description=HI.AVERAGE_INCOME)
     percentage_high_income: Optional[float] = Field(default=None, description=HI.PERCENTAGE_HIGH_INCOME)
     percentage_low_income: Optional[float] = Field(default=None, description=HI.PERCENTAGE_LOW_INCOME)
-    gdhi_per_person: Optional[float] = Field(default=None, description=HI.GDHI_PER_PERSON)
+    gdhi_per_person: Optional[EconomicsValue] = Field(default=None, description=HI.GDHI_PER_PERSON)
 
 
 class HouseholdIncomeKeys:
@@ -39,9 +39,31 @@ class HouseholdIncomeKeys:
 ###########################################
 ########## Start Model defenition #########
 ###########################################
+class WagesLegends:
+    AVERAGE_MONTHLY_WAGE = "Gross median wages per month."
+    AVERAGE_WEEKLY_WAGE = "Gross median wages per week."
+
+
+WL = WagesLegends
+
+
+class Wages(DataGardenSubModel):
+    average_monthly_wage: Optional[EconomicsValue] = Field(default=None, description=WL.AVERAGE_MONTHLY_WAGE)
+    average_weekly_wage: Optional[EconomicsValue] = Field(default=None, description=WL.AVERAGE_WEEKLY_WAGE)
+
+
+class WagesKeys:
+    AVERAGE_MONTHLY_WAGE = "average_monthly_wage"
+    AVERAGE_WEEKLY_WAGE = "average_weekly_wage"
+
+
+###########################################
+########## Start Model defenition #########
+###########################################
 class EconomicsLegends:
     HOUSEHOLD_INCOME = "Average household income."
     SOCIAL_WELFARE_BENEFIT = "Population count with social welfare benefit other then pension."
+    WAGES = "Wage information."
 
 
 EL = EconomicsLegends
@@ -52,8 +74,10 @@ class Economics(DataGardenSubModel):
     social_welfare_benefit: Optional[ValueAndPercentage] = Field(
         default=None, description=EL.SOCIAL_WELFARE_BENEFIT
     )
+    wages: Optional[Wages] = Field(default=None, description=EL.WAGES)
 
 
-class EconomicsKeys(HouseholdIncomeKeys):
+class EconomicsKeys(HouseholdIncomeKeys, WagesKeys):
     HOUSEHOLD_INCOME = "household_income"
+    WAGES = "wages"
     SOCIAL_WELFARE_BENEFIT = "social_welfare_benefit"


### PR DESCRIPTION
Added wages model to economics submodel for household model

Changes to be committed:
	modified:   pyproject.toml
	modified:   src/datagarden_models/models/household/economics.py