### PR TITLE
DGDM-21-Add-productivity-submodel-to-economics-model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "the-datagarden-models"
-version = "1.6.16"
+version = "1.6.18"
 description = "Base data models for the datagarden."
 readme = "README.rst"
 requires-python = ">=3.10"

--- a/src/datagarden_models/models/economics/__init__.py
+++ b/src/datagarden_models/models/economics/__init__.py
@@ -5,6 +5,7 @@ from .base_economics import EconomicBaseKeys, EconomicMetaDataKeys, EconomicsMet
 from .gdp import GDP, GDPV1Keys
 from .inflation import Inflation, InflationV1Keys
 from .labor_market import LaborMarketStatus, LaborMarketStatusKeys
+from .productivity import Productivity, ProductivityKeys
 from .public_spending import PublicSpendingV1, PublicSpendingV1Keys
 from .trade import TradeV1, TradeV1Keys
 
@@ -17,6 +18,7 @@ class EconomicsV1Keys(
     PublicSpendingV1Keys,
     EconomicMetaDataKeys,
     LaborMarketStatusKeys,
+    ProductivityKeys,
 ):
     GDP = "gdp"
     ECONOMICS_METADATA = "economics_metadata"
@@ -25,6 +27,7 @@ class EconomicsV1Keys(
     TRADE = "trade"
     PUBLIC_SPENDING = "public_spending"
     LABOR_MARKET_STATUS = "labor_market_status"
+    PRODUCTIVITY = "productivity"
 
 
 class EconomicsV1Legends(DataGardenModelLegends):
@@ -33,6 +36,7 @@ class EconomicsV1Legends(DataGardenModelLegends):
     TRADE = "Trade statistics"
     PUBLIC_SPENDING = "Public spending"
     LABOR_MARKET_STATUS = "Labor market status"
+    PRODUCTIVITY = "Productivity statistics"
     ECONOMICS_METADATA = "Metadata about currency, units and reference year used for the data."
     MODEL_LEGEND = "Economic data for a region. "
 
@@ -50,3 +54,4 @@ class EconomicsV1(DataGardenModel):
     labor_market_status: LaborMarketStatus = Field(
         default_factory=LaborMarketStatus, description=L.LABOR_MARKET_STATUS
     )
+    productivity: Productivity = Field(default_factory=Productivity, description=L.PRODUCTIVITY)

--- a/src/datagarden_models/models/economics/productivity.py
+++ b/src/datagarden_models/models/economics/productivity.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+from pydantic import Field
+
+from datagarden_models.models.base import DataGardenSubModel, EconomicsValue
+
+
+###########################################
+########## Start Model defenition #########
+###########################################
+class ProductivityLegends:
+    VALUE_ADDED_PER_WORKED_HOUR = "Value added per worked hour."
+
+
+PL = ProductivityLegends
+
+
+class Productivity(DataGardenSubModel):
+    value_added_per_worked_hour: Optional[EconomicsValue] = Field(
+        default=None, description=PL.VALUE_ADDED_PER_WORKED_HOUR
+    )
+
+
+class ProductivityKeys:
+    VALUE_ADDED_PER_WORKED_HOUR = "value_added_per_worked_hour"


### PR DESCRIPTION
Added productivity submodel to economics model

Changes to be committed:
	modified:   pyproject.toml
	modified:   src/datagarden_models/models/economics/__init__.py
	new file:   src/datagarden_models/models/economics/productivity.py